### PR TITLE
Conjunction Expansion made to handle tree and alpha similar patterns are removed!

### DIFF
--- a/experiments/rules/conj-exp/main.py
+++ b/experiments/rules/conj-exp/main.py
@@ -95,6 +95,8 @@ def flatten_list(nested_list):
             flat_list.append(current)
     return flat_list
 
+# Permutations not implemented yet and also the conjunction vars must be returned with the
+# generated combinations
 def combine_lists_recursive(list1, list2, length, current_combination=None, index1=0, index2=0):
     if current_combination is None:
         current_combination = []
@@ -112,29 +114,29 @@ def combine_lists_recursive(list1, list2, length, current_combination=None, inde
         new_combination = current_combination + [list2[j]]
         combinations.extend(combine_lists_recursive(list1, list2, length, new_combination, index1, j + 1))
 
-    return combinations
+    return (unique_combinations(combinations, list1, list2))
 
 def combine_lists(list1, list2):
-    length = max(len(list1), len(list2))
+    length = len(list2)
     return combine_lists_recursive(list1, list2, length)
 
 
-# def unique_combinations(combinations, list1, list2):
-#     flat_list1 = flatten_list(list1)
-#     flat_list2 = flatten_list(list2)
+def unique_combinations(combinations, list1, list2):
+    flat_list1 = flatten_list(list1)
+    flat_list2 = flatten_list(list2)
     
-#     seen = set()
-#     unique_combos = []
-#     list1_set = set(str(item) for item in flat_list1)
-#     list2_set = set(str(item) for item in flat_list2)
+    seen = set()
+    unique_combos = []
+    list1_set = set(str(item) for item in flat_list1)
+    list2_set = set(str(item) for item in flat_list2)
 
-#     for combo in combinations:
-#         sorted_combo = tuple(sorted(str(item) for item in combo))
-#         combo_set = set(sorted_combo)
-#         if sorted_combo not in seen and combo_set != list1_set and combo_set != list2_set:
-#             seen.add(sorted_combo)
-#             unique_combos.append(combo)
-#     return unique_combos
+    for combo in combinations:
+        sorted_combo = tuple(sorted(str(item) for item in combo))
+        combo_set = set(sorted_combo)
+        if sorted_combo not in seen and combo_set != list1_set and combo_set != list2_set:
+            seen.add(sorted_combo)
+            unique_combos.append(combo)
+    return unique_combos
 
 @register_atoms(pass_metta=True)
 def cnj_exp(metta):

--- a/experiments/rules/conj-exp/main.py
+++ b/experiments/rules/conj-exp/main.py
@@ -1,197 +1,99 @@
-# from hyperon import *
-# from hyperon.ext import register_atoms
-# import re
-# import sys
-# import os
-# import random
-# import string
-# import time
+from hyperon import *
+from hyperon.ext import register_atoms
+import re
+import sys
+import os
+import random
+import string
+import time
 
-# from hyperon.atoms import ExpressionAtom, E, GroundedAtom, OperationAtom, ValueAtom, NoReduceError, AtomType, MatchableObject, VariableAtom,\
-#     G, S,V, Atoms, get_string_value, GroundedObject, SymbolAtom
-# from hyperon.base import Tokenizer, SExprParser
-# from hyperon.ext import register_atoms, register_tokens
-# import hyperonpy as hp
+from hyperon.atoms import ExpressionAtom, E, GroundedAtom, OperationAtom, ValueAtom, NoReduceError, AtomType, MatchableObject, VariableAtom,\
+    G, S,V, Atoms, get_string_value, GroundedObject, SymbolAtom
+from hyperon.base import Tokenizer, SExprParser
+from hyperon.ext import register_atoms, register_tokens
+import hyperonpy as hp
 
-# def combine_lists_op(metta: MeTTa, var1, var2):
-#     #($Y ($X ())) ($a  ($b ($c ())))
-#     input_str1 = str(var1)
-#     input_str2 = str(var2)
+def combine_lists_op(metta: MeTTa, var1, var2):
     
-#     list1 = parse_list_structure(input_str1)
-#     list2 = parse_list_structure(input_str2) 
-
-#     combinations = combine_lists(list1, list2)
+    input_str1 = str(var1)
+    input_str2 = str(var2)
     
-#     # unique_combos = unique_combinations(combinations, list1, list2)
+    list1 = parse_metta_structure(input_str1)
+    list2 = parse_metta_structure(input_str2) 
+
+    combinations = combine_lists(list1, list2)
     
-#     # This generates dynamic combinations with a variable number of elements
-#     combined_pattern = " ".join(
-#         ["({})".format(" ".join(combo)) for combo in combinations]
-#     )
+    combined_pattern = " ".join(
+        ["({})".format(" ".join(combo)) for combo in combinations]
+    )
 
-#     combined_pattern_atoms = "(" + combined_pattern + ")"
+    combined_pattern_atoms = "(" + combined_pattern + ")"
 
-#     atoms = metta.parse_all(combined_pattern_atoms)
-#     return atoms
+    atoms = metta.parse_all(combined_pattern_atoms)
+    return atoms
 
 # def format_list(metta: MeTTa, list):
-#     """
-#     Formats a flat list of elements into groups that end with "End", and then
-#     parses it into an Atom using the MeTTa instance.
-
-#     Args:
-#         metta (MeTTa): The MeTTa instance.
-#         list (Atom): The input nested list structure as an Atom.
-
-#     Returns:
-#         Atom: The formatted list of groups as an Atom.
-#     """
-    
 #     input_str = str(list)
-#     parsed_structure = parse_list_structure(input_str)
+#     parsed_structure = parse_metta_structure(input_str)
 
 #     flat_list = flatten_list(parsed_structure)
 
 #     grouped_list = []
 #     current_group = []
 
-#     # Group elements until you hit "End"
 #     for item in flat_list:
 #         if item == "End":
-#             if current_group:  # Ensure we're not appending empty groups
+#             if current_group:
 #                 grouped_list.append(f"({' '.join(current_group)})")
-#             current_group = []  # Reset for the next group
+#             current_group = []
 #         else:
 #             current_group.append(item)
 
-mapping = {}
-    
-def generate_random_string(length=1):
-        """
-        Generates a random string of specified length composed of uppercase letters and digits.
+#     formatted_list = " ".join(grouped_list)
+#     formatted_list_ready = "(" + formatted_list + ")"
 
-        Parameters:
-        - length (int): The length of the random string to generate. Default is 1.
+#     formatted_atom = metta.parse_all(formatted_list_ready)
 
-        Returns:
-        - A random string of uppercase letters and digits.
-        """
-        return ''.join(random.choices(string.ascii_uppercase + string.digits, k=length))
+#     return formatted_atom
 
-def extract_variables_from_atom(atom):
-        """
-        Extracts variable names from a given atom. Variables are identified by a leading '$' symbol.
-        Variables containing '#' are ignored as they are considered invalid.
-
-        Parameters:
-        - atom: The atom from which to extract variable names.
-
-        Returns:
-        - A list of valid variable names extracted from the atom.
-        """
-        atom_str = str(atom)
-        pattern = r"\$[^\s\(\)]+"
-        variables = re.findall(pattern, atom_str)
-        return [var for var in variables if "#" not in var]
-
-def generate_random_var(metta:MeTTa,a, b):
-        """
-        Generates a unique variable name based on the variables extracted from two atoms.
-        If a variable name for 'b' is already generated and stored in the mapping, it returns that variable.
-        Otherwise, it generates a new unique variable name, stores it in the mapping, and returns it.
-
-        Parameters:
-        - a: The first atom from which to extract variables.
-        - b: The second atom from which to extract variables and for which to generate a unique variable name.
-
-        Returns:
-        - A list containing the newly generated unique variable.
-        """
-        if str(a) in mapping:
-            atom = metta.parse_all(mapping[str(a)])
-        variables = extract_variables_from_atom(a)
-        variables_set = set(var[1:] for var in variables)
-        base_name = "$rn" + generate_random_string() + str(int(time.time()))
-
-        if base_name in variables_set:
-            i = 1
-            while f"{base_name}{i}" in variables_set:
-                i += 1
-            base_name = f"{base_name}{i}"
-
-        base_name = "("+base_name +")"
-        mapping[str(a)] = base_name
-        atom = metta.parse_all(base_name)
-
-        return atom
-
-
-def combine_lists_op(metta: MeTTa, var1, var2):
-    #($Y ($X ())) ($a  ($b ($c ())))
-    input_str1 = str(var1)
-    input_str2 = str(var2)
-    
-    list1 = parse_list_structure(input_str1.replace('"', ''))
-    list2 = parse_list_structure(input_str2.replace('"', ''))
-
-    combinations = combine_lists(list1, list2)
-    
-    unique_combos = unique_combinations(combinations, list1, list2)
-    
-    combined_pattern = " ".join(["({} {} {})".format(combo[0], combo[1], combo[2]) for combo in unique_combos])
-    combined_pattern_atoms = "(" + combined_pattern + ")"
-
-    atoms = metta.parse_all(combined_pattern_atoms)
-    return atoms
-
-def parse_list_structure(input_str):
-    """Convert a string with parentheses into a nested list structure."""
+def parse_metta_structure(input_str):
+    """Convert a string like ($A $B $C) into a flat list ['$A', '$B', '$C']"""
     elements = []
     current = ""
     in_word = False
     
     for char in input_str:
         if char == '(':
-            if in_word:
-                elements.append(f'"{current.strip()}", ')
-                current = ""
-                in_word = False
-            elements.append('[')
+            continue  # Skip parentheses and dollar signs
         elif char == ')':
             if in_word:
-                elements.append(f'"{current.strip()}"')
+                elements.append(current.strip())
                 current = ""
                 in_word = False
-            elements.append('], ')
         elif char.isspace():
             if in_word:
-                elements.append(f'"{current.strip()}", ')
+                elements.append(current.strip())
                 current = ""
                 in_word = False
         else:
             current += char
             in_word = True
-    
+
     if in_word:
-        elements.append(f'"{current.strip()}"')
+        elements.append(current.strip())
     
-    parsed_str = ''.join(elements)
-    
-    parsed_str = parsed_str.replace(', ]', ']')
-    parsed_str = parsed_str.rstrip(', ')
-    
-    return eval(parsed_str)
+    return elements
 
 def flatten_list(nested_list):
-    """Flatten a nested list structure into a flat list of elements."""
-    if isinstance(nested_list, list):
-        flat_list = []
-        for item in nested_list:
-            flat_list.extend(flatten_list(item))
-        return flat_list
-    else:
-        return [nested_list]
+    flat_list = []
+    stack = [nested_list]
+    while stack:
+        current = stack.pop()
+        if isinstance(current, list):
+            stack.extend(reversed(current))
+        else:
+            flat_list.append(current)
+    return flat_list
 
 def combine_lists_recursive(list1, list2, length, current_combination=None, index1=0, index2=0):
     if current_combination is None:
@@ -213,27 +115,26 @@ def combine_lists_recursive(list1, list2, length, current_combination=None, inde
     return combinations
 
 def combine_lists(list1, list2):
-    flat_list1 = flatten_list(list1)
-    flat_list2 = flatten_list(list2)
-    length = max(len(flat_list1), len(flat_list2))
-    return combine_lists_recursive(flat_list1, flat_list2, length)
+    length = max(len(list1), len(list2))
+    return combine_lists_recursive(list1, list2, length)
 
-def unique_combinations(combinations, list1, list2):
-    flat_list1 = flatten_list(list1)
-    flat_list2 = flatten_list(list2)
+
+# def unique_combinations(combinations, list1, list2):
+#     flat_list1 = flatten_list(list1)
+#     flat_list2 = flatten_list(list2)
     
-    seen = set()
-    unique_combos = []
-    list1_set = set(str(item) for item in flat_list1)
-    list2_set = set(str(item) for item in flat_list2)
+#     seen = set()
+#     unique_combos = []
+#     list1_set = set(str(item) for item in flat_list1)
+#     list2_set = set(str(item) for item in flat_list2)
 
-    for combo in combinations:
-        sorted_combo = tuple(sorted(str(item) for item in combo))
-        combo_set = set(sorted_combo)
-        if sorted_combo not in seen and combo_set != list1_set and combo_set != list2_set:
-            seen.add(sorted_combo)
-            unique_combos.append(combo)
-    return unique_combos
+#     for combo in combinations:
+#         sorted_combo = tuple(sorted(str(item) for item in combo))
+#         combo_set = set(sorted_combo)
+#         if sorted_combo not in seen and combo_set != list1_set and combo_set != list2_set:
+#             seen.add(sorted_combo)
+#             unique_combos.append(combo)
+#     return unique_combos
 
 @register_atoms(pass_metta=True)
 def cnj_exp(metta):
@@ -243,19 +144,71 @@ def cnj_exp(metta):
         lambda var1, var2: combine_lists_op(metta, var1, var2), 
         ['Atom', 'Atom', 'Expression'], 
         unwrap=False)
+    # formatList = OperationAtom(
+    #     'format_list', 
+    #     lambda list: format_list(metta, list), 
+    #     ['Atom', 'Expression'], 
+    #     unwrap=False)
     
-
-    
-    
-        # Define the operation atom with its parameters and function
-    genRandomVar = OperationAtom('genRandomVar', lambda var1, var2: (print(var1,var2),generate_random_var(metta,var1, var2))[1],
-                                      ['Atom', 'Atom', 'Expression'], 
-                                      unwrap=False)
-
-   
     return {
         r"combine_lists": combineLists,
-        r"genRandomVar": genRandomVar
+        # r"format_list": formatList
     }
 
 
+@register_atoms(pass_metta=True)
+def rand_str(run_context):
+    """
+    This function registers an operation atom `generateRandomVar` that dynamically generates a unique variable name.
+    It ensures the generated variable name is not already used within the given context. The uniqueness is achieved by
+    combining a random string with the current timestamp, and checking against existing variables in the atom.
+
+    The operation atom `generateRandomVar` takes a single atom as input and generates a new variable that does not conflict
+    with any existing variable names extracted from this atom.
+
+    Parameters:
+    - run_context: The context in which this function is run, provided by the caller.
+
+    Returns:
+    - A dictionary mapping the operation name to the OperationAtom instance.
+    """
+
+    def generate_random_string(length=1):
+        """
+        Generates a random string of specified length composed of uppercase letters and digits.
+
+        Parameters:
+        - length (int): The length of the random string to generate. Default is 1.
+
+        Returns:
+        - A random string of uppercase letters and digits.
+        """
+        return ''.join(random.choices(string.ascii_uppercase + string.digits, k=length))
+
+    def generate_random_var(atom):
+        """
+        Generates a unique variable name based on the input atom.
+        Assumes the input atom is a variable, like "$A".
+
+        Parameters:
+        - atom: The atom from which to generate a unique variable name.
+
+        Returns:
+        - A list containing the newly generated unique variable.
+        """
+        atom_str = str(atom)
+        clean_str = atom_str.replace('$', '').replace('#', '')
+
+        # Create a new unique variable name by appending random string and timestamp
+        base_name = 'R-' + generate_random_string() + str(int(time.time()))
+        new_var = V(base_name)
+
+        return [new_var]
+
+    # Define the operation atom with its parameters and function
+    generateRandomVar = OperationAtom('generateRandomVar', lambda atom: generate_random_var(atom),
+                                      ['Atom','Expression'], unwrap=False)
+
+    return {
+        r"generateRandomVar": generateRandomVar
+    }

--- a/experiments/rules/conj-exp/main.py
+++ b/experiments/rules/conj-exp/main.py
@@ -1,60 +1,44 @@
 from hyperon import *
 from hyperon.ext import register_atoms
-import re
-import sys
-import os
 import random
 import string
 import time
-
-from hyperon.atoms import ExpressionAtom, E, GroundedAtom, OperationAtom, ValueAtom, NoReduceError, AtomType, MatchableObject, VariableAtom,\
-    G, S,V, Atoms, get_string_value, GroundedObject, SymbolAtom
-from hyperon.base import Tokenizer, SExprParser
-from hyperon.ext import register_atoms, register_tokens
-import hyperonpy as hp
+from hyperon.atoms import OperationAtom, V
+from hyperon.ext import register_atoms
+import itertools
+from itertools import combinations
 
 def combine_lists_op(metta: MeTTa, var1, var2):
-    
     input_str1 = str(var1)
     input_str2 = str(var2)
-    
+
     list1 = parse_metta_structure(input_str1)
     list2 = parse_metta_structure(input_str2) 
 
-    combinations = combine_lists(list1, list2)
-    
+    combinations = range_combinations(list1, list2)
     combined_pattern = " ".join(
         ["({})".format(" ".join(combo)) for combo in combinations]
     )
 
     combined_pattern_atoms = "(" + combined_pattern + ")"
-
     atoms = metta.parse_all(combined_pattern_atoms)
     return atoms
 
-# def format_list(metta: MeTTa, list):
-#     input_str = str(list)
-#     parsed_structure = parse_metta_structure(input_str)
+def range_combinations(list1, list2):
+    merged_list = list1 + list2
+    i, j = len(list2), len(list2)
+    res = []
+    for sub in range(j):
+        if sub >= (i - 1):
+            res.extend(combinations(merged_list, sub + 1))
+    
+    res = [combo for combo in res if not set(combo).issubset(set(list2))]
 
-#     flat_list = flatten_list(parsed_structure)
-
-#     grouped_list = []
-#     current_group = []
-
-#     for item in flat_list:
-#         if item == "End":
-#             if current_group:
-#                 grouped_list.append(f"({' '.join(current_group)})")
-#             current_group = []
-#         else:
-#             current_group.append(item)
-
-#     formatted_list = " ".join(grouped_list)
-#     formatted_list_ready = "(" + formatted_list + ")"
-
-#     formatted_atom = metta.parse_all(formatted_list_ready)
-
-#     return formatted_atom
+    all_permutations = []
+    for combo in res:
+        perms = [list(p) for p in itertools.permutations(combo)]
+        all_permutations.extend(perms)
+    return all_permutations
 
 def parse_metta_structure(input_str):
     """Convert a string like ($A $B $C) into a flat list ['$A', '$B', '$C']"""
@@ -64,7 +48,7 @@ def parse_metta_structure(input_str):
     
     for char in input_str:
         if char == '(':
-            continue  # Skip parentheses and dollar signs
+            continue
         elif char == ')':
             if in_word:
                 elements.append(current.strip())
@@ -84,133 +68,22 @@ def parse_metta_structure(input_str):
     
     return elements
 
-def flatten_list(nested_list):
-    flat_list = []
-    stack = [nested_list]
-    while stack:
-        current = stack.pop()
-        if isinstance(current, list):
-            stack.extend(reversed(current))
-        else:
-            flat_list.append(current)
-    return flat_list
+def generate_random_string(length=1):
+    return ''.join(random.choices(string.ascii_uppercase + string.digits, k=length))
 
-# Permutations not implemented yet and also the conjunction vars must be returned with the
-# generated combinations
-def combine_lists_recursive(list1, list2, length, current_combination=None, index1=0, index2=0):
-    if current_combination is None:
-        current_combination = []
-    
-    if len(current_combination) == length:
-        return [current_combination]
-    
-    combinations = []
-    
-    for i in range(index1, len(list1)):
-        new_combination = current_combination + [list1[i]]
-        combinations.extend(combine_lists_recursive(list1, list2, length, new_combination, i + 1, index2))
+def generate_random_var():
+    base_name = 'R-' + generate_random_string() + str(int(time.time()))
+    new_var = V(base_name)
 
-    for j in range(index2, len(list2)):
-        new_combination = current_combination + [list2[j]]
-        combinations.extend(combine_lists_recursive(list1, list2, length, new_combination, index1, j + 1))
-
-    return (unique_combinations(combinations, list1, list2))
-
-def combine_lists(list1, list2):
-    length = len(list2)
-    return combine_lists_recursive(list1, list2, length)
-
-
-def unique_combinations(combinations, list1, list2):
-    flat_list1 = flatten_list(list1)
-    flat_list2 = flatten_list(list2)
-    
-    seen = set()
-    unique_combos = []
-    list1_set = set(str(item) for item in flat_list1)
-    list2_set = set(str(item) for item in flat_list2)
-
-    for combo in combinations:
-        sorted_combo = tuple(sorted(str(item) for item in combo))
-        combo_set = set(sorted_combo)
-        if sorted_combo not in seen and combo_set != list1_set and combo_set != list2_set:
-            seen.add(sorted_combo)
-            unique_combos.append(combo)
-    return unique_combos
+    return [new_var]
 
 @register_atoms(pass_metta=True)
 def cnj_exp(metta):
-    
-    combineLists = OperationAtom(
-        'combine_lists', 
-        lambda var1, var2: combine_lists_op(metta, var1, var2), 
-        ['Atom', 'Atom', 'Expression'], 
-        unwrap=False)
-    # formatList = OperationAtom(
-    #     'format_list', 
-    #     lambda list: format_list(metta, list), 
-    #     ['Atom', 'Expression'], 
-    #     unwrap=False)
-    
+    combineLists = OperationAtom('combine_lists', lambda var1, var2: combine_lists_op(metta, var1, var2), 
+                                 ['Atom', 'Atom', 'Expression'],unwrap=False)
+    generateRandomVar = OperationAtom('generateRandomVar', lambda: generate_random_var(),
+                                      ['Expression'], unwrap=False)
     return {
         r"combine_lists": combineLists,
-        # r"format_list": formatList
-    }
-
-
-@register_atoms(pass_metta=True)
-def rand_str(run_context):
-    """
-    This function registers an operation atom `generateRandomVar` that dynamically generates a unique variable name.
-    It ensures the generated variable name is not already used within the given context. The uniqueness is achieved by
-    combining a random string with the current timestamp, and checking against existing variables in the atom.
-
-    The operation atom `generateRandomVar` takes a single atom as input and generates a new variable that does not conflict
-    with any existing variable names extracted from this atom.
-
-    Parameters:
-    - run_context: The context in which this function is run, provided by the caller.
-
-    Returns:
-    - A dictionary mapping the operation name to the OperationAtom instance.
-    """
-
-    def generate_random_string(length=1):
-        """
-        Generates a random string of specified length composed of uppercase letters and digits.
-
-        Parameters:
-        - length (int): The length of the random string to generate. Default is 1.
-
-        Returns:
-        - A random string of uppercase letters and digits.
-        """
-        return ''.join(random.choices(string.ascii_uppercase + string.digits, k=length))
-
-    def generate_random_var(atom):
-        """
-        Generates a unique variable name based on the input atom.
-        Assumes the input atom is a variable, like "$A".
-
-        Parameters:
-        - atom: The atom from which to generate a unique variable name.
-
-        Returns:
-        - A list containing the newly generated unique variable.
-        """
-        atom_str = str(atom)
-        clean_str = atom_str.replace('$', '').replace('#', '')
-
-        # Create a new unique variable name by appending random string and timestamp
-        base_name = 'R-' + generate_random_string() + str(int(time.time()))
-        new_var = V(base_name)
-
-        return [new_var]
-
-    # Define the operation atom with its parameters and function
-    generateRandomVar = OperationAtom('generateRandomVar', lambda atom: generate_random_var(atom),
-                                      ['Atom','Expression'], unwrap=False)
-
-    return {
         r"generateRandomVar": generateRandomVar
     }

--- a/experiments/rules/conjunction-expansion.metta
+++ b/experiments/rules/conjunction-expansion.metta
@@ -54,6 +54,8 @@
     )
 )
 
+(= (count-atom-element $atom) (if (== $atom ()) 0 (+ 1 (count-atom-element (cdr-atom $atom)))))
+
 (= (get_variables_for_tree $pattern)
     (if (== $pattern ())
         ()
@@ -233,4 +235,4 @@
 (INHERITANCE_LINK A D)
 
  ;(expand_conjunction_inputs cnjtion pattern db ms mv es)
- ; ! (expand_conjunction (INHERITANCE_LINK $X $Y) (LIST_LINK $X $B) &self 0 2 False)
+! (expand_conjunction (INHERITANCE_LINK $X $Y) (LIST_LINK $X $B) &self 0 2 False)

--- a/experiments/rules/conjunction-expansion.metta
+++ b/experiments/rules/conjunction-expansion.metta
@@ -22,7 +22,7 @@
 
 ! (register-module! ../../experiments)
 ! (import! &self experiments:utils:common-utils)
- ; ! (import! &self conj-exp)
+! (import! &self conj-exp)
 
  ; The starting point for the conjunction expansion. It passes
  ; the Alpha Converted pattern (if necessary) to the expand_conjunction functions.
@@ -30,111 +30,178 @@
 
 (= (expand_conjunction $cnjtion $pattern $db $ms $mv $es)
     (let* (
-            ($apat (alpha_convert $cnjtion $pattern)))
+            ($apat (let $alpha_vars
+                    (alpha_convert (get_variables_for_tree $pattern) (get_variables_for_tree $cnjtion))
+                    (let $extract (substitute $pattern $alpha_vars) (car-atom $extract)))))
         (if (> (let* (
-                        ($temp (get_variables $pattern))
-                        ($temp2 (get_variables $cnjtion)))
-                    (+ (length $temp) (length $temp2))) $mv)
+                        ($temp (get_variables_for_tree $pattern))
+                        ($temp2 (get_variables_for_tree $cnjtion)))
+                    (+ (count-atom-element  $temp) (count-atom-element  $temp2))) $mv)
             (if $es
-                (expand_conjunctin_es_rec $cnjtion $apat $db $ms $pattern)
-                (expand_conjunction_rec $cnjtion $apat $db $ms $pattern))
+                (expand_conjunctin_es_rec $cnjtion $apat $db $ms)
+                (expand_conjunction_rec $cnjtion $apat $db $ms))
             ())
     )
 )
 
- ; Alpha convert pattern so that none of its variables collide with
- ; the variables in other_vars.
-
-(= (alpha_convert ($link1 $x1 $y1) ($link2 $x2 $y2))
-    (if (and (== $x1 $x2) (== $y1 $y2))
-        ($link2 $X-78235323 $y2)
-        ($link2 $x2 $y2)
-    )
-)
-(= (alpha_convert ($link1 $x1 $y1) ($link2 $x2 $y2))
-    (if (and (== $x1 $x2) (== $y1 $y2))
-        ($link2 $x2 $Y-78235323)
-        ($link2 $x2 $y2)
+(= (concatTuple $xs $ys)
+    (if (== $xs ())
+        $ys
+        (let* ( ($head (car-atom $xs))
+                ($tail (cdr-atom $xs))
+                ($tailNew (concatTuple $tail $ys)))
+            (cons-atom $head $tailNew))
     )
 )
 
-(:reverse (-> List List))
+(= (get_variables_for_tree $pattern)
+    (if (== $pattern ())
+        ()
+        (let* (
+                ($head (car-atom $pattern))
+                ($tail (cdr-atom $pattern)))
 
-(= (reverse ()) ())
-(= (append () $ele) ( $ele ()))
+            (if (== (get-metatype $head) Expression)
+                (concatTuple (get_variables_for_tree $head)
+                    (get_variables_for_tree $tail))
+                (if (== (get-metatype $head) Variable)
+                    (concatTuple
+                        ($head)
+                        (get_variables_for_tree $tail))
 
-(= (append ( $x $xs) $ele)
-    ( $x (append $xs $ele)))
-(= (reverse ( $x $xs))
-    (append (reverse $xs) $x))
-
-(= (handle $x ($xs)) (cons-atom $xs $x))
-(= (handle $val ($x $y))
-    (let $z (cons-atom $x $val) (handle $z $y) )
+                    (get_variables_for_tree $tail))))
+    )
 )
 
-(= (get_elements  () ()) ())
-(= (get_elements $val ($elm ()))  ( (cons-atom $elm $val)))
-( = (get_elements $val ($x ($xs $xss)))
-    (
-        if (== $x End)
-        (get_elements () ($xs $xss))
-        (
-            if ( == $xs End)
-            ( (cons-atom $x $val) (get_elements () $xss))
-            (let $f (cons-atom $x $val ) (get_elements $f  ($xs $xss)) )
-        )
-))
+ ; ! (get_variables_for_tree (Inheritance (Human $X) (Inheritance $Y (Human $Z))))
 
-
- ;TODO1
- ;Check if the same variable with is used for replacement
- ;if that is the case replace it with the replacement variabele
- ;used for replacing that variable
-(= (find-replacement $var $variables)
+(= (substitute $pattern $variables)
     (if (== $variables ())
-        $var
-        (if (== $var (car-atom $variables))
-            (genRandomVar $set)
-             ; $rand
-            (find-replacement $var (let* (
-                        ($temp (cdr-atom $variables))
-                        ($tail (car-atom $temp)))
-                    $tail)))
+        ()
+        (if (== $pattern ())
+            (substitute $pattern (cdr-atom $variables))
+            (let* (
+                    ($head (car-atom $pattern))
+                    ($tail (cdr-atom $pattern)))
+
+                (if (== (get-metatype $head) Expression)
+                    (case $head
+                        ( ( ($link $x $y) (concatTuple
+                                    (substitute $head $variables)
+                                    (substitute $tail (let $temp (cdr-atom $variables) (cdr-atom $temp)))))
+                            ( ($link $x ) (concatTuple
+                                    (substitute $head $variables)
+                                    (substitute $tail (cdr-atom $variables))))))
+
+                    (if (== (get-metatype $head) Variable)
+                        (concatTuple ( (car-atom $variables)) (substitute $tail (cdr-atom $variables)))
+                        ( (concatTuple ($head) (substitute $tail $variables)))))))
     )
-
- ; Parse a list that is like:- (Inheritance ($X ($Y (End (Inheritance ($X ($Y (End  ...))))))))
- ; into ((Inheritance $X $Y) (Inheritance $X $Y) ...) FOR later combination with cnjtion and
- ; pattern matching against the db
-
-(= (parse_list ($x ($xs $xss)))
-    (handle () (get_elements  () (reverse ($x ($xs $xss)))))
-
-
 )
 
-(= (expand_conjunction_rec $cnjtion $apat $db $ms $pattern)
-    (let $npat (let $temp (expand_conjunction_connect $cnjtion $apat) (parse_list $temp))
-        (checker $db (reconstruct $cnjtion $npat) $ms))
+ ; ! (substitute (Inheritance (Human $X) (Inheritance $Y (Human $Z))) ($A $B $C))
+
+ ;############################################################
+ ;###############   alpha convert  ###########################
+ ;############################################################
+
+(= (alpha_convert  $pattern_vars $cnjtion_vars)
+    (extract_values (consolidate_keys (address_conflict $pattern_vars $cnjtion_vars)))
+)
+(= (address_conflict $pattern_vars $cnjtion_vars)
+    (if (== $pattern_vars ())
+        ()
+        (let* (
+                ($head (car-atom $pattern_vars))
+                ($tail (cdr-atom $pattern_vars)))
+            (if (does_exist $head $cnjtion_vars)
+                (concatTuple ( ($head (generateRandomVar $set))) (address_conflict $tail $cnjtion_vars ))
+                (concatTuple ( ($head $head)) (address_conflict $tail $cnjtion_vars))))
+    )
 )
 
- ; Simulate support evaluation since the support implementation currently takes
- ; lots of minutes to check just one support and I have to check more than 20 pattern's support
-
-(= (support_evaluation $db $pattern $ms)
-    (let $sup (counter $db $pattern)
-        (if (>= $sup $ms)
+(= (does_exist $var $list_vars)
+    (if (== $list_vars ())
+        False
+        (if (== $var (car-atom $list_vars))
             True
-            False)
+            (does_exist $var (cdr-atom $list_vars)))
     )
 )
 
-(= (length ()) 0)
-(= (length ($x $xs))
-    (+ 1 (length $xs)))
+(= (consolidate_keys $input_list)
+    (let* (
+            ($result ())
+            ($seen_keys ()))
+        (consolidate_helper $input_list $result $seen_keys)
+    )
+)
 
- ; This function checks if the patterns generated pass support evaluation and the conjunction passes n_conjuncts check
- ; (The implementation for n_conjunction in the common-utils.metta seems incorrect. I don't know maybe I am wrong :)
+(= (consolidate_helper $input_list $result $seen_keys)
+    (if (== $input_list ())
+        $result
+        (let* (
+                ($pair (car-atom $input_list))
+                ($key (car-atom $pair))
+                ($value (cdr-atom $pair)))
+            (if (does_exist $key $seen_keys)
+                (consolidate_helper (cdr-atom $input_list)
+                    (concatTuple ( ($key (let $temp (get_value $key $result) (car-atom $temp)))) $result)
+                    $seen_keys)
+                (let* (
+                        ($new_result (let $temp (cons-atom $key $value) (cons-atom $temp $result)))
+                        ($new_seen_keys (cons-atom $key $seen_keys)))
+                    (consolidate_helper (cdr-atom $input_list) $new_result $new_seen_keys))))
+    )
+)
+
+(= (get_value $key $list)
+    (if (== $list ())
+        ()
+        (if (== $key (let $temp (car-atom $list) (car-atom $temp)))
+            (let $temp2 (car-atom $list) (cdr-atom $temp2))
+            (get_value $key (cdr-atom $list)))
+    )
+)
+
+(= (extract_values $input_list)
+    (extract_helper $input_list ())
+)
+
+(= (extract_helper $input_list $values)
+    (if (== $input_list ())
+        $values
+        (let* (
+                ($pair (car-atom $input_list))
+                ($value (cdr-atom $pair))
+                ($tail (cdr-atom $input_list)))
+            (extract_helper $tail (cons-atom (car-atom $value) $values)))
+    )
+)
+
+ ; ! (alpha_convert ($A $B $F $A $F) ($A $C $D $F))
+ ; ! (alpha_convert ($A $B $C ) ($X $Y $Z))
+
+ ;#############################################################
+ ;############   alpha convert end  ###########################
+ ;#############################################################
+
+(= (expand_conjunction_rec $cnjtion $apat $db $ms)
+    (let $npat (expand_conjunction_connect $cnjtion $apat (get_variables_for_tree $cnjtion) (get_variables_for_tree $apat))
+        (checker $db (let $single (collapse $npat) (car-atom $single)) $ms))
+)
+
+(= (expand_conjunction_connect $cnjtion $pattern $cv $pv)
+    (replace_pattern $cnjtion $pattern (combine_lists $cv $pv))
+)
+
+(= (replace_pattern $cnjtion $pattern $pv2cv)
+    (if (== $pv2cv ())
+        ()
+        ( (, $cnjtion (let $exp (substitute $pattern (car-atom $pv2cv)) (car-atom $exp)))
+            (replace_pattern $cnjtion $pattern (cdr-atom $pv2cv)))
+    )
+)
 
 (= (checker $db () $ms) ())
 (= (checker $db ($x $xs) $ms)
@@ -144,66 +211,14 @@
     )
 )
 
- ; Combine and reconstruct are functions to combine each patterns generated with
- ; the conjunction and then reconstruct them into a list.
- ; It will create something like this: ((, (Inheritance $X $Y) (Inheritance $X $W)) ...)
-
-(= (combine $cnjtion $pattern)
-    (if (== $patterns ())
-        ()
-        (cons-atom , ($cnjtion $pattern))
+(= (support_evaluation $db $pattern $ms)
+    (let $sup (counter $db $pattern)
+        (if (>= $sup $ms)
+            True
+            False)
     )
 )
 
-(= (reconstruct $cnjtion $xs)
-    (if (== $xs ())
-        ()
-        ( (combine $cnjtion (car-atom $xs)) (reconstruct $cnjtion (cdr-atom $xs)))
-    )
-)
-
- ; If the patterns are only two variables with the link
- ; If that is not the case I have written a python grounded function named combine_lists to find
- ; the combinations between every variable in the pattern and the conjunction
-
-(= (generate-combinations ($link1 $x $y) ($link2 $a $b))
-    (   ($x $a)
-        ($x $b)
-        ($y $a)
-        ($y $b)
-        ($a $x)
-        ($a $y)
-        ($b $x)
-        ($b $y)
-    )
-)
-
-(= (expand_conjunction_connect $cnjtion $pattern)
-    (expand_conjunction_connect $cnjtion $pattern (generate-combinations  $cnjtion $pattern))
-)
-
- ; This function create the patterns using the combined variables from the
- ; Pattern and the Conjunction. It will create a list of patterns that can be used for combination later with conjunction.
- ; It will create something like: (Inheritance ($X ($Y (End (Inheritance ($X ($Y (End  ...))))))))
-
-(= (expand_conjunction_connect $cnjtion $pattern $pv2cv)
-    (if (== $pv2cv ())
-        ()
-        (pattern_var_replacer $pattern $pattern (car-atom $pv2cv) $cnjtion $pv2cv)
-    )
-)
-
-(= (pattern_var_replacer $ori_pattern $pattern $var $cnjtion $pv2cv)
-    (if (== $pattern ())
-        (End (expand_conjunction_connect $cnjtion $ori_pattern (cdr-atom $pv2cv)))
-        (if (is-variable (car-atom $pattern))
-            ( (car-atom $var) (pattern_var_replacer $ori_pattern (cdr-atom $pattern) (cdr-atom $var) $cnjtion $pv2cv))
-            ( (car-atom $pattern) (pattern_var_replacer $ori_pattern (cdr-atom $pattern) $var $cnjtion $pv2cv)))
-    )
-)
-
- ; The implementation has no difference with the expand_conjunction_rec
- ; in the C++ code.
 (= (expand_conjunction_es_rec $cnjtion $apat $db $ms)
     (pass)
 )
@@ -218,7 +233,4 @@
 (INHERITANCE_LINK A D)
 
  ;(expand_conjunction_inputs cnjtion pattern db ms mv es)
-! (expand_conjunction (INHERITANCE_LINK $X $Y) (LIST_LINK $X $Y) &self 1 2 False)
-
- ; One CE output for (Inheritance $X $Y) (LIST_LINK $X $Y) with ms 2
-! (match &self (, (INHERITANCE_LINK $X $Y) (LIST_LINK $Y $X-78235323)) ($X $Y $X-78235323))
+ ; ! (expand_conjunction (INHERITANCE_LINK $X $Y) (LIST_LINK $X $B) &self 0 2 False)

--- a/experiments/rules/conjunction-expansion.metta
+++ b/experiments/rules/conjunction-expansion.metta
@@ -44,16 +44,6 @@
     )
 )
 
-(= (concatTuple $xs $ys)
-    (if (== $xs ())
-        $ys
-        (let* ( ($head (car-atom $xs))
-                ($tail (cdr-atom $xs))
-                ($tailNew (concatTuple $tail $ys)))
-            (cons-atom $head $tailNew))
-    )
-)
-
 (= (count-atom-element $atom) (if (== $atom ()) 0 (+ 1 (count-atom-element (cdr-atom $atom)))))
 
 (= (get_variables_for_tree $pattern)
@@ -75,7 +65,7 @@
     )
 )
 
- ; ! (get_variables_for_tree (Inheritance (Human $X) (Inheritance $Y (Human $Z))))
+ ;! (get_variables_for_tree  (Inheritance (Human $X) (Inheritance $Y (Human $Z))))
 
 (= (substitute $pattern $variables)
     (if (== $variables ())
@@ -101,7 +91,7 @@
     )
 )
 
- ; ! (substitute (Inheritance (Human $X) (Inheritance $Y (Human $Z))) ($A $B $C))
+ ;! (substitute (Inheritance (Human $X) (Inheritance $Y (Human $Z))) ($A $B $C))
 
  ;############################################################
  ;###############   alpha convert  ###########################
@@ -130,6 +120,8 @@
             (does_exist $var (cdr-atom $list_vars)))
     )
 )
+
+ ; ! (address_conflict ($A $B $F $A $F) ($A $C $D $F))
 
 (= (consolidate_keys $input_list)
     (let* (
@@ -181,7 +173,7 @@
     )
 )
 
- ; ! (alpha_convert ($A $B $F $A $F) ($A $C $D $F))
+ ;! (alpha_convert ($A $B $F $A $F) ($A $C $D $F))
  ; ! (alpha_convert ($A $B $C ) ($X $Y $Z))
 
  ;#############################################################
@@ -194,7 +186,7 @@
 )
 
 (= (expand_conjunction_connect $cnjtion $pattern $cv $pv)
-    (replace_pattern $cnjtion $pattern (combine_lists $cv $pv))
+    (let $list (replace_pattern $cnjtion $pattern (combine_lists $cv $pv)) (remove_alpha_similar $list))
 )
 
 (= (replace_pattern $cnjtion $pattern $pv2cv)
@@ -221,9 +213,41 @@
     )
 )
 
+(= (remove_alpha_similar $list)
+    (remove_alpha_similar_helper $list ())
+)
+
+(= (remove_alpha_similar_helper ($listHead $listTail) $seen_list)
+    (if (== $listTail ())
+        ()
+        (let* (
+                ($matched (collapse (match &self $listHead $listHead)))
+                ($seen_list_new (concatTuple ($matched) $seen_list)))
+            (if (or (== $matched ()) (does_exist $matched $seen_list)) ;(or (== $matched ()) )but supp evaluation will check this
+                (remove_alpha_similar_helper $listTail $seen_list)
+                ( $listHead (remove_alpha_similar_helper $listTail $seen_list_new))))
+    )
+)
+
 (= (expand_conjunction_es_rec $cnjtion $apat $db $ms)
     (pass)
 )
+
+(= ( expand_conjunction_disconnect $cnjtion $pattern ) (
+        let* (
+            ($cnjtion_vars (get_variables_for_tree $cnjtion))
+            ($pat_vars  (get_variables_for_tree $pattern))
+            ($acvar (alpha_convert $pat_vars $cnjtion_vars))
+            ($acpat (let $pat (substitute $pattern $acvar) (car-atom $pat)))
+            ($npat (append_pat $cnjtion $acpat))
+            ($nclause (remove_redundant_subclauses $npat))
+        ) $nclause
+))
+
+(= ( append_pat $pat $conj) ( , $pat $conj))
+
+! (expand_conjunction_disconnect (INHERITANCE_LINK $X $Y) (LIST_LINK $X $B))
+
  ;##############
  ;# Test cases #
  ;##############
@@ -231,8 +255,13 @@
  ;Populate the Atomspace with some data
 
 (INHERITANCE_LINK A B)
+(LIST_LINK A B)
+(List_LINK A C)
 (LIST_LINK B C)
 (INHERITANCE_LINK A D)
+(INHERITANCE_LINK X Y)
+(LIST_LINK Y C)
+(INHERITANCE_LINK X D)
 
  ;(expand_conjunction_inputs cnjtion pattern db ms mv es)
-! (expand_conjunction (INHERITANCE_LINK $X $Y) (LIST_LINK $X $B) &self 0 2 False)
+ ;! (expand_conjunction (INHERITANCE_LINK $X $Y) (LIST_LINK $X $B) &self 1 2 False)

--- a/experiments/rules/conjunction-expansion.metta
+++ b/experiments/rules/conjunction-expansion.metta
@@ -107,7 +107,7 @@
                 ($head (car-atom $pattern_vars))
                 ($tail (cdr-atom $pattern_vars)))
             (if (does_exist $head $cnjtion_vars)
-                (concatTuple ( ($head (generateRandomVar $set))) (address_conflict $tail $cnjtion_vars ))
+                (concatTuple ( ($head (generateRandomVar))) (address_conflict $tail $cnjtion_vars ))
                 (concatTuple ( ($head $head)) (address_conflict $tail $cnjtion_vars))))
     )
 )
@@ -246,7 +246,7 @@
 
 (= ( append_pat $pat $conj) ( , $pat $conj))
 
-! (expand_conjunction_disconnect (INHERITANCE_LINK $X $Y) (LIST_LINK $X $B))
+ ; ! (expand_conjunction_disconnect (INHERITANCE_LINK $X $Y) (LIST_LINK $X $B))
 
  ;##############
  ;# Test cases #
@@ -256,7 +256,7 @@
 
 (INHERITANCE_LINK A B)
 (LIST_LINK A B)
-(List_LINK A C)
+(LIST_LINK A C)
 (LIST_LINK B C)
 (INHERITANCE_LINK A D)
 (INHERITANCE_LINK X Y)
@@ -264,4 +264,5 @@
 (INHERITANCE_LINK X D)
 
  ;(expand_conjunction_inputs cnjtion pattern db ms mv es)
- ;! (expand_conjunction (INHERITANCE_LINK $X $Y) (LIST_LINK $X $B) &self 1 2 False)
+! (expand_conjunction (INHERITANCE_LINK $X $Y) (LIST_LINK $X $B) &self 1 2 False)
+ ; ! (match &self (, (INHERITANCE_LINK $X $Y) (LIST_LINK $A $Y)) (, (INHERITANCE_LINK $X $Y) (LIST_LINK $A $Y))) ; This is alpha similar to (X Y) (X Y) COMB

--- a/experiments/utils/common-utils.metta
+++ b/experiments/utils/common-utils.metta
@@ -27,22 +27,14 @@
     )
 )
 
-
-(: counter (-> hyperon::space::DynSpace Atom Number))
-(= (counter $db ($link $x))
-    (let $result (collapse (match $db ($link $x) ($link $x)))
-        (tuple-count $result)
-    )
-)
-
-; Count the number of instances of a given pattern
+ ; Count the number of instances of a given pattern
 (= (count $pattern $db)
-    (let* (($dptrn (Debruijn2var $pattern (Cons $Xvar (Cons $Yvar Nil))))
-           ($result (collapse (match $db $dptrn $dptrn))))
+    (let* ( ($dptrn (Debruijn2var $pattern (Cons $Xvar (Cons $Yvar Nil))))
+            ($result (collapse (match $db $dptrn $dptrn))))
         (tuple-count $result)))
 
-;; Evaluate if the pattern has enough support
-;; Evaluate if the pattern has enough support
+ ;; Evaluate if the pattern has enough support
+ ;; Evaluate if the pattern has enough support
 (: sup-eval (-> hyperon::space::DynSpace Atom Number Boolean))
 
 (= (sup-eval $db ($link $x $y) $ms)
@@ -50,8 +42,6 @@
         (if (>= $sup $ms) (CandidatePattern (Var2Debruijn ($link $x $y))) (superpose ()))
     )
 )
-
-
 
  ;Check if expression is truth value or not
 (: cog-tv? (-> Atom Boolean))
@@ -101,21 +91,23 @@
 (: classify_integer_position (-> Number String))
 (= (classify_integer_position $x)
     (if (> $x 0)
-        1 ; Return 1 if x is greater than zero
+        ("Greater than zero")
         (case (equals-to-zero $x)
             (
-                (False -1) ; Return -1 if x is less than zero
-                (True 0))))) ; Return 0 if x is equal to zero
+                (False "Less than zero")
+                (True "Equal to zero")))))
  ;; pow is a function that calculates a to the power of b where a and b are numbers
 (: pow (-> Number Number Number))
 (= (pow $a $b)
     (case (classify_integer_position $b)
         (
-            (0 1)
-            (-1 (/ 1 (pow $a (abs $b))))
+            ("Equal to zero" 1)
+            ("Less than zero" (/ 1 (pow $a (abs $b))))
             ($_ (* $a (pow $a (- $b 1))))
         )
-))
+)
+)
+
  ;; universe count
 (= (universe-count $pattern $db)
     (pow (db_size $db) (n_conjuncts $pattern))
@@ -231,7 +223,7 @@
 (= (is_variable_joint_with_clauses $variable $clauses)
     (if (== $clauses ())
         False ; If no clauses are left, return False
-        (let* (<<<<<<< experiments
+        (let* (
                 ($clause_vars (let $temp (car-atom $clauses) (get_variables $temp))) ; Extract variables from the current clause
             )
          ; Check if the variable is in the current clause's variables
@@ -301,58 +293,75 @@
  ;     )
  ; ))
 
-(= (is_subclause $clause $expr)
-    (if (== $expr ())
-        False
-        (if (== $clause (car-atom $expr)) ; If the clause matches the first element
-            True
-            (is_subclause $clause (cdr-atom $expr))) ; Otherwise, check the rest
+ ;helper function to concat two tuples
+(= (concatTuple $xs $ys)
+    (if (== $xs ())
+        $ys
+        (let* ( ($head (car-atom $xs))
+                ($tail (cdr-atom $xs))
+                ($tailNew (concatTuple $tail $ys)))
+            (cons-atom $head $tailNew))
     )
 )
 
- ;########################
- ; Remove Redundunt subclauses from the list of clauses
- ; It currently checks for subclauses in one depth.
- ; It can be extended to check for subclauses within subclauses
+ ;! (concatTuple (A B C) (D E F))
 
- ; Main function to process and remove redundant clauses from the expression
-(= (remove_redundant_subclauses $exp)
-    (process_expressions_for_redundant_subclauses $exp $exp)
-)
-
- ; Outer loop to process the entire expression list
-(= (process_expressions_for_redundant_subclauses $expr $original_expr)
-    (if (== $expr ()) ; No more clauses, return empty
+(= (is_subclause_helper $head $pattern)
+    (if (== $pattern ())
         ()
         (let* (
-                ($current_clause (car-atom $expr)) ; Get the current clause
-                ($remaining_expr (cdr-atom $expr))) ; Get the rest of the expression
-            (if (is_clause_redundant $current_clause $original_expr) ; Check if current clause is redundant
-                (process_expressions_for_redundant_subclauses $remaining_expr $original_expr) ; Skip redundant clause
-                ($current_clause (process_expressions_for_redundant_subclauses $remaining_expr $original_expr))))
+                ($headP (car-atom $pattern))
+                ($tail (cdr-atom $pattern)))
+
+            (if (== (get-metatype $headP) Expression)
+                (if (== $head $headP)
+                    (True)
+                    (concatTuple (is_subclause_helper $head $headP)
+                        (is_subclause_helper $head $tail)))
+                (is_subclause_helper $head $tail)
+            ))
+
+)
+)
+(= (is_subclause $pattern1 $pattern2)
+    (let $flag (is_subclause_helper $pattern1 $pattern2)
+        (if (== $flag ())
+            False
+            True)
     )
 )
 
- ; Check if the current clause is redundant by comparing with remaining expressions
-(= (is_clause_redundant $clause $remaining_expr)
-    (check_nested_subclauses $clause $remaining_expr) ; Check deeper for nested redundancy
-)
-
- ; Go deeper into the structure and check nested subclauses
-(= (check_nested_subclauses $clause $remaining_expr)
-    (if (== $remaining_expr ())
-        False
+(= (remove_current $current_clause $original_expr)
+    (if (== $original_expr ())
+        ()
         (let* (
-                ($next_clause (car-atom $remaining_expr)) ; Get the next clause
-                ($remaining_rest (cdr-atom $remaining_expr))
-                ($is_redundant (or
-                        (is_subclause $clause $next_clause) ; Check for subclause in the nested list
-                        (check_nested_subclauses $clause $remaining_rest))))
-            $is_redundant )
+                ($head (car-atom $original_expr))
+                ($tail (cdr-atom $original_expr)))
+            (if (== $head $current_clause)
+                (remove_current $current_clause $tail)
+                (concatTuple ($head) (remove_current $current_clause $tail))))
     )
 )
 
- ; ! (remove_redundant_subclauses ( (Mortal $W) (Implies (Human $X) (Mortal $X))  (Human $X) ))
+(= (remove_redundant_subclauses $exp)
+    (remove_redundant_subclauses_helper $exp $exp)
+)
+
+(= (remove_redundant_subclauses_helper $expr $original_expr)
+    (if (== $expr ())
+        ()
+        (let* (
+                ($current_clause (car-atom $expr))
+                ($remaining_expr (cdr-atom $expr))
+                ($ori_exp_without_current (remove_current $current_clause $original_expr)))
+            (if (is_subclause $current_clause $ori_exp_without_current)
+                (remove_redundant_subclauses_helper $remaining_expr $original_expr)
+                (concatTuple ($current_clause ) (remove_redundant_subclauses_helper $remaining_expr $original_expr))))
+    )
+)
+
+ ; ! (is_subclause (Implies $x $y) (Implies (Human (Implies $x $y)) (Mortal $X)))
+ ; ! (remove_redundant_subclauses (, (Implies $x $W) (Implies (Human (Implies $x $y) (Mortal $X))) (Mortal $X) ))
 
  ; ##############################
 (= (is_more_abstract ($link1 $x1 $y1) ($link2 $x2 $y2) $relative_var)


### PR DESCRIPTION
I have modified most of the code based on Hedra and Nil's comments. From this modifications some implemented functions include:
 - get_variables_for_tree
 - remove_alpha_similar
 - remove_redundant_subclause made to handle tree structure.
 - expand_conjunction_disconnect 
