### PR TITLE
create a test for isurp

### DIFF
--- a/experiments/rules/isurp.metta
+++ b/experiments/rules/isurp.metta
@@ -116,15 +116,52 @@
 )
 
 
-; (=(do-ji-prob $partitions $pattern $db $db_ratio) (
-;   if (== $partitions ()) () (
-;      let* ((($partition $tail) (decons-atom $partitions))
-;             ($jip (ji-prob-est $partition $pattern $db $db_ratio))
-;              ($dummy (do-ji-prob $tail $pattern $db $db_ratio)))
-;              (cons-atom $jip $dummy) ))
-; )
 
+;; =============================================================================
+;; Function: do-ji-prob
+;; -----------------------------------------------------------------------------
+;; Purpose:
+;;   Recursively computes joint inclusion probabilities (JI-Probs) for a pattern
+;;   across multiple partitions in a database, returning a list of probability estimates.
+;;
+;; Inputs:
+;;   - `$partitions`: List of data partitions to analyze (e.g., `(P1 P2 P3)`)
+;;   - `$pattern`: The target pattern to evaluate (e.g., `(P A B)`)
+;;   - `$db`: Reference database for probability estimation
+;;   - `$db_ratio`: Database ratio parameter for probability calculation
+;;
+;; Output:
+;;   - List of JI-Prob estimates for each partition (e.g., `(0.8 0.6 0.9)`)
+;;   - Empty list if no partitions provided
+;;
+;; How it works:
+;;   1. Base Case: Returns empty list when partitions are exhausted
+;;   2. Recursive Case:
+;;      a. Extracts current partition and remaining partitions
+;;      b. Computes JI-Prob using `ji-prob-est` helper
+;;      c. Recursively processes remaining partitions
+;;      d. Combines results while preserving order
+;;
+;; Notes:
+;;   - Requires `ji-prob-est` helper function
+;;   - Preserves partition order in results
+;;   - Time Complexity: O(n) where n = partition count
+;;   - Space Complexity: O(n) for result storage
+;;
+;; Examples:
+;;   (do-ji-prob '(P1 P2) '(P A B) DB 0.5) → (0.7 0.6)
+;;   (do-ji-prob '() '(P X) DB 0.1) → ()
+;; =============================================================================
+(=(do-ji-prob $partitions $pattern $db $db_ratio) (
+  if (== $partitions ()) () (
+     let* ((($partition $tail) (decons-atom $partitions))
+            ($jip (ji-prob-est $partition $pattern $db $db_ratio))
+             ($dummy (do-ji-prob $tail $pattern $db $db_ratio)))
+             (cons-atom $jip $dummy) ))
+)
 
+; TODO:  check why the superpose is not working
+;; ==============================================================
 ;; Previous Implementation: ^
 ;; - Utilizes explicit recursion to operate over the list of partitions.
 ;; - Decomposes the partitions list using a deconstructing approach (decons-atom).
@@ -144,9 +181,9 @@
 ;;   the partitions via superposition and collapse.
 ;; - The new implementation simplifies the code and leverages metta's capabilities to avoid deep recursion.
 
-(=(do-ji-prob $partitions $pattern $db $db_ratio) (
-   collapse (ji-prob-est (superpose $partitions) $pattern $db $db_ratio)
-))
+; (=(do-ji-prob $partitions $pattern $db $db_ratio) (
+;    collapse (ji-prob-est (superpose $partitions) $pattern $db $db_ratio)
+; ))
 
 
 

--- a/experiments/tests/test-isurp.metta
+++ b/experiments/tests/test-isurp.metta
@@ -12,44 +12,32 @@
 ! (import! &self experiments:rules:isurp)
 ! (import! &self experiments:rules:emp-prob)
 ! (import! &kb experiments:data:ugly_man_sodaDrinker)
+! (import! &self experiments:utils:eq_prob_adaptor)
 
 
 
 
 
-! (bind! square (py-atom numpy.square (-> Number Number)))
+
+
+
+!(assertEqual (ji_prob_est_interval (, (Ixnheritance $x $y)  (Inheritance Abe $y) (Inheritance Zac $y)) (get-space) 2) 2)
+
+
+!(assertEqual (ji-prob-est (((Inheritance $x man) (Inheritance $x sodaDrinker)) ((Inheritance $x ugly)))  (, (Inheritance $x man) (Inheritance $x ugly) (Inheritance $x sodaDrinker))  &kb 0.5) 0.009135566413047788)
+
+!(assertEqual (do-ji-prob ((((Inheritance $x man) (Inheritance $x sodaDrinker)) ((Inheritance $x ugly))) (((Inheritance $x man) (Inheritance $x ugly)) ((Inheritance $x sodaDrinker))) (((Inheritance $x man)) ((Inheritance $x sodaDrinker)) ((Inheritance $x ugly))) (((Inheritance $x man)) ((Inheritance $x sodaDrinker) (Inheritance $x ugly)))) 
+                            (, (Inheritance $x man) (Inheritance $x ugly) (Inheritance $x sodaDrinker))
+                            &Kb 
+                            0.5
+                          )
+               (0.1 0.1 0.01 0.1)
+ )
+
+ !(assertEqual (ji_prob_est_interval (, (Inheritance $x man) (Inheritance $x ugly) (Inheritance $x sodaDrinker) ) &kb  0.2) (0.009135566413047788 0.13155215634788814))
 
 
 
 
-! (add-reduct &self (= (get-space) (new-space)))
-! (add-atom (get-space) (Inheritance Abe human))
-! (add-atom (get-space) (Inheritance Abe human))
-! (add-atom (get-space) (Inheritance Abe human))
-
-! (add-atom (get-space) (Inheritance Rio human))
-! (add-atom (get-space) (Inheritance Bob human))
-! (add-atom (get-space) (Inheritance Mike human))
-! (add-atom (get-space) (Inheritance Zac human))
-! (add-atom (get-space) (Inheritance Zac human))
-! (add-atom (get-space) (Parent Abe Nil ))
-
-! (add-atom (get-space)  (Inheritance Bob (And human (Or zac))) ) 
 
 
-;!(ji_prob_est_interval (,(Inheritance $x $y)  (Inheritance Abe $y) (Inheritance Zac $y)) (get-space) 2)
-;!(isurp (,(Inheritance $x $y)  (Inheritance Abe $y) (Inheritance Zac $y)) (get-space) True 2)
-;!(isurp (,(Inheritance $x sodaDrinker) (Inheritance $x human) (Inheritance $x woman)) &kb True 0.5)
-!(Here)
-!(match (get-space) (Inheritance $x human) $x)
-
-
-;[0.6455555555555555]
-;!(generet-partition-without-pattern (,(Inheritance $x $y)  (Inheritance Abe $y)))
-;!(generet-partition-without-pattern (,(Inheritance $x $y)  (Inheritance Abe $y) (Inheritance Zac $y)))
-
-[((((Inheritance $x $y) (Inheritance Abe $y)) ((Inheritance Zac $y)))
-
-  (((Inheritance $x $y)) ((Inheritance Abe $y)) ((Inheritance Zac $y))) 
-  (((Inheritance $x $y)) ((Inheritance Abe $y) (Inheritance Zac $y))) 
-  (((Inheritance $x $y) (Inheritance Zac $y)) ((Inheritance Abe $y))))]


### PR DESCRIPTION
This pull request refactors the `do-ji-prob` function in `experiments/rules/isurp.metta` to improve clarity and maintainability while updating related test cases in `experiments/tests/test-isurp.metta`. The changes include adding detailed documentation for the function, modifying its implementation, and introducing new test cases to validate its behavior.

### Refactoring and Documentation Updates:
* Added comprehensive documentation for the `do-ji-prob` function, describing its purpose, inputs, outputs, and implementation details. This includes examples and complexity analysis to improve code readability and usage understanding. (`[experiments/rules/isurp.mettaL119-R164](diffhunk://#diff-4c11bc67f7db3e9beea6c28694f60d2025db8ac040e1bd28e8e132637d72f9caL119-R164)`)
* Replaced a previous commented-out implementation of `do-ji-prob` with a well-documented recursive approach that computes joint inclusion probabilities while preserving partition order. (`[experiments/rules/isurp.mettaL119-R164](diffhunk://#diff-4c11bc67f7db3e9beea6c28694f60d2025db8ac040e1bd28e8e132637d72f9caL119-R164)`)

### Test Suite Enhancements:
* Introduced new test cases in `experiments/tests/test-isurp.metta` to validate the behavior of `do-ji-prob` and related functions, such as `ji-prob-est` and `ji-prob-est-interval`. These tests ensure correctness for various input scenarios. (`[experiments/tests/test-isurp.mettaR15-L55](diffhunk://#diff-8b07f92a52f75e463f8e966ee03971afd286e293c301b2ecbff52879be63d8d3R15-L55)`)
* Removed redundant or outdated test cases and bindings, streamlining the test file for clarity and relevance. (`[experiments/tests/test-isurp.mettaR15-L55](diffhunk://#diff-8b07f92a52f75e463f8e966ee03971afd286e293c301b2ecbff52879be63d8d3R15-L55)`)