### PR TITLE
added the metta implementation that converts debrujin form of patterns to their variable forms and vice-versa

### DIFF
--- a/experiments/utils/debrujin2var.metta
+++ b/experiments/utils/debrujin2var.metta
@@ -1,0 +1,100 @@
+; Converts a list of De Bruijn indices and symbols to variables, accumulating result in $acc, using $fixed-vars as the variable pool.
+
+
+
+
+(= (debruijn2num Z) 0)
+
+(= (debruijn2num (S $k)) (+ 1 (debruijn2num $k)))
+
+(= (debruijn2vars-acc $lst $acc $fixed-vars)
+   (if (== $lst ())
+       $acc
+       (let* (
+           ($head (car-atom $lst))
+           ($tail (cdr-atom $lst))
+         )
+         (if (or (== (get-metatype $head) Expression) (== $head Z))
+             (let* (
+                 ($idx (debruijn2num $head))
+                 ($var (index-atom $fixed-vars $idx))
+               )
+               (debruijn2vars-acc $tail (union-atom $acc ($var)) $fixed-vars)
+             )
+             (debruijn2vars-acc $tail (union-atom $acc ($head)) $fixed-vars)
+         )
+       )
+   )
+)
+
+
+; Converts a single subpattern in De Bruijn form to variable form using debruijn2vars-acc
+(= (debruijn-subpattern2vars $subpat $fixed-vars)
+   (let* (
+       ($head (car-atom $subpat))
+       ($args (cdr-atom $subpat))
+       ($vars-args (debruijn2vars-acc $args () $fixed-vars))
+       ($new-subpat (cons-atom $head $vars-args))
+     )
+     $new-subpat
+   )
+)
+
+; (: debruijn-conjuncts2vars-acc (-> (List $a) (List $b) (List $c) (List $c)))
+
+; Converts a list of subpatterns in De Bruijn form to variable form, accumulating result in $acc, using $fixed-vars as the variable pool.
+(= (debruijn-conjuncts2vars-acc $subpats $fixed-vars $acc)
+   (if (== $subpats ())
+       $acc
+       (let* (
+          
+           (($subpat $tail) (decons-atom $subpats))
+          
+           (($head $args ) (decons-atom $subpat))
+           ($vars-args (debruijn2vars-acc $args () $fixed-vars))
+           ($new-subpat (cons-atom $head $vars-args))
+           ($new-acc (union-atom $acc ($new-subpat)))
+         )
+         (debruijn-conjuncts2vars-acc $tail $fixed-vars $new-acc)
+       )
+   )
+)
+
+(= (debruijn-conjunct-pattern2vars $conjunct $fixed-vars)
+   (let* (
+       ($subpats (cdr-atom $conjunct))
+       ($vars-subpats (debruijn-conjuncts2vars-acc $subpats $fixed-vars ()))
+       ($vars-conjunct (cons-atom , $vars-subpats))
+     )
+     $vars-conjunct
+   )
+)
+
+(= (full-pattern2vars $pattern)
+   (if (== (car-atom $pattern) ,)
+       (debruijn-conjunct-pattern2vars $pattern ($x $y $z $f $i $j $k $l $m $n $o $p $q))
+       (debruijn-subpattern2vars $pattern ($x $y $z $f $i $j $k $l $m $n $o $p $q))
+       
+   )
+)
+;use this version cuz when we try to pass the list of variables within the body it acts wierd os its better to get the list from the user directly as argument
+(= (full2-pattern2vars $pattern $fixed-vars)
+      (if (== (car-atom $pattern) ,)
+       (debruijn-conjunct-pattern2vars $pattern $fixed-vars)
+       (debruijn-subpattern2vars $pattern $fixed-vars)
+       
+     
+   
+))
+
+
+;acts werid cuz the list of variables are being passed within the body of the fucntion 
+!(full-pattern2vars (Inheritance abe Z) )
+;[(Inheritance abe $x#37)] this is the output
+
+!(full2-pattern2vars (Inheritance abe Z) ($x $y $z $f $i $j $k $l $m $n $o $p $q))
+;[(Inheritance $y $z)] output 
+
+;(: type1 Variable)
+;(= (check $b) (let $x (type-cast $b type1 &self) (get-metatype $x)))
+;type-casting the debrujin directly into variables would have been better for scalability than using a hardcoded fixed list of variables but typecasting doesn't seem to work properly

--- a/experiments/utils/subpattern-withvar.metta
+++ b/experiments/utils/subpattern-withvar.metta
@@ -1,0 +1,57 @@
+(=(is-pattern $expr) (
+    collapse(
+ or (unify $expr ($link $x $y) (
+       and (is-symbol $link) (
+        or (or (is-variable $x) (is-expression $x))
+             (or (is-variable $y) (is-expression $y)))) False)
+    (unify $expr ($link $x) 
+       (and (is-symbol $link) 
+        (or (is-variable $x) 
+            (is-expression $x))) False ) )))
+            
+(=(is-present $atom ()) False)
+(=(is-present $atom $list) (
+    if (is-expression $list) (
+    let ($head $tail) (decons-atom $list) (
+        if (== $atom $head) True  (or (is-present $atom $head) (is-present $atom $tail))
+    )) (if (== $atom $head) True False)))
+
+(=(is-symbol $var) 
+   (== (get-metatype $var) Symbol)
+)
+
+(=(is-variable $var) 
+   (== (get-metatype $var) Variable)
+)
+
+(=(is-expression $var) 
+  (== (get-metatype $var) Expression)
+)
+
+(=(checkIntersection $var $set) 
+    (not (== ((intersection-atom ($var) $set)) (())))) 
+
+(=(process-pattern $acc $pattern $var)
+ (if (== (get-metatype $pattern) Symbol) 
+        $acc 
+        (let* (
+                ($is_pattern (let $pat_temp (is-pattern $pattern) (car-atom $pat_temp))) 
+                ($is_expression (== (get-metatype $pattern) Expression)) 
+                ($vars (cdr-atom $pattern)) 
+                ($is_connected (checkIntersection $var $vars))) 
+            (if (and (and $is_pattern $is_expression) $is_connected)
+                (cons-atom $pattern $acc) 
+                $acc))))
+
+(=(connected-subpatterns-with-var $partition $var)
+    (foldl-atom $partition () $acc $pattern (process-pattern $acc $pattern $var)))
+
+
+
+!(connected-subpatterns-with-var (, (Inheritance $x $y) (Inheritance $y $z) (Inheritance $j $f) (Constant 42) (Inheritance $z $k)) $y)
+
+
+
+
+
+

--- a/experiments/utils/var2debrujin.metta
+++ b/experiments/utils/var2debrujin.metta
@@ -1,0 +1,111 @@
+(= (nat2debruijn $n) (if (== $n 0) Z (S (nat2debruijn (- $n 1)))))
+
+
+
+; Main entry point
+(= (get-var-index $var-list $target-var)
+   (if (== ((intersection-atom $var-list ($target-var))) (()))
+       (let* (
+           ($updated-list (union-atom $var-list ($target-var)))
+           ($idx (- (size-atom $updated-list) 1))
+         )
+         ($updated-list $idx)
+       )
+       (get-var-index-helper $var-list $target-var 0 $var-list)
+   )
+)
+
+; Recursive helper: walks the list, increments counter until target is found
+(= (get-var-index-helper $list $target-var $counter $orig-list)
+   (if (== (car-atom $list) $target-var)
+       ($orig-list $counter)
+       (get-var-index-helper (cdr-atom $list) $target-var (+ 1 $counter) $orig-list)
+   )
+)
+  
+
+
+
+
+
+; Main function: converts variables in $lst to De Bruijn indices, accumulates result in $acc, tracks seen variables in $seen
+(= (vars2debruijn-acc $lst $acc $seen)
+   (if (== $lst ())
+       ($acc $seen)
+       (let* (
+           ($head (car-atom $lst))
+           ($tail (cdr-atom $lst))
+         )
+         (if (not (== (get-metatype $head) Variable))
+             (vars2debruijn-acc $tail (union-atom $acc ($head)) $seen)
+             (let* (
+                ;   (($updated-seen $idx) (get-var-index $seen $head))
+                 ($idx-result (get-var-index $seen $head))
+                 ($updated-seen (car-atom $idx-result))
+                 ($int (cdr-atom $idx-result))
+                 ($idx (car-atom $int))
+                 ($debruijn (nat2debruijn $idx))
+               )
+               (vars2debruijn-acc $tail (union-atom $acc ($debruijn)) $updated-seen)
+             )
+         )
+       )
+   )
+)
+
+
+
+; Main function: converts each subpattern in $subpats to De Bruijn form, accumulates result in $acc, tracks seen variables in $seen
+(= (conjuncts2debruijn-acc $subpats $seen $acc)
+   (if (== $subpats ())
+       $acc
+       (let* (
+    
+           (($subpat $tail) (decons-atom $subpats))
+      
+           (($head $args) (decons-atom $subpat))
+           ($deb-result (vars2debruijn-acc $args () $seen))
+     
+           (($deb-args $int) (decons-atom $deb-result))
+           ($updated-seen (car-atom $int))
+           ($new-subpat (cons-atom $head $deb-args))
+           ($new-acc (union-atom $acc ($new-subpat)))
+         )
+         (conjuncts2debruijn-acc $tail $updated-seen $new-acc)
+       )
+   )
+)
+;if we are dealing with a single pattern instead of a conjunct.
+(= (subpattern2debruijn $subpat $seen)
+   (let* (
+       ($head (car-atom $subpat))
+       ($args (cdr-atom $subpat))
+       ($deb-result (vars2debruijn-acc $args () $seen))
+       ($deb-args (car-atom $deb-result))
+       ; $updated-seen is available as (car-atom (cdr-atom $deb-result)) if needed
+       ($debruijn-subpat (cons-atom $head $deb-args))
+     )
+     $debruijn-subpat
+   )
+)
+
+; Converts a conjunct pattern (with leading comma) to De Bruijn form.
+(= (conjunct-pattern2debruijn $conjunct $seen)
+   (let* (
+       ($subpats (cdr-atom $conjunct))
+       ($deb-result (conjuncts2debruijn-acc $subpats $seen ()))
+       
+       ($debruijn-conjunct (cons-atom , $deb-result))
+     )
+     $debruijn-conjunct
+   )
+)
+
+
+(= (pattern2debruijn $pattern)
+   (if (== (car-atom $pattern) ,)
+      (conjunct-pattern2debruijn $pattern ())
+      (subpattern2debruijn $pattern ())
+       
+   )
+)


### PR DESCRIPTION
For the deb2var conversion implmentation although it works for now using hardcoded list of varaibles to choose from, once the type-cast method is patched in metta, I will add another implementaion that involves converting the debrujin indicices which are of type Expression into type variables and use that essentially generating variables on the go.