### PR TITLE
Fix joint-independent truth value estimation: import paths, unification, confidence constant, and pattern handling

### DIFF
--- a/experiments/tests/SurprisingnessUTest.metta
+++ b/experiments/tests/SurprisingnessUTest.metta
@@ -6,7 +6,7 @@
 ! (import! &self experiments:utils:surp-utils)
 ! (import! &self experiments:utils:miner-utils)
 ! (import! &self experiments:utils:gen_partition)
-! (import! &self experiments:rules:est-tv)
+! (import! &self experiments:truth-values:est-tv)
 
 ! (bind! square (py-atom numpy.square (-> Number Number)))
 

--- a/experiments/truth-values/emp-tv.metta
+++ b/experiments/truth-values/emp-tv.metta
@@ -65,7 +65,7 @@
 ;; Returns:
 ;;   - A confidence value between 0 and 1
 ;; =============================================================================
-(= (count_to_confidence $x) (// $x (+ $x (Default_k))))
+(= (count_to_confidence $x) (// $x (+ $x (DEFAULT_K))))
 
 ;; =============================================================================
 ;; Function: emp-tv
@@ -88,7 +88,7 @@
         (  
             ( ($ucount ) ( (universe-count $pattern $db)))
             ( ($ms) ($ucount)) ;;  we didn't use ms for support calculation
-            ( ($sup) ( (sup-num $pattern $db)))
+            ( ($sup) ( (sup-num $db $pattern)))
             ( ($conf) ( (count_to_confidence $ucount)) )
             ($mean (// $sup $ucount))
             ($confidence   (* 1e-1 $conf))

--- a/experiments/truth-values/tests/test-est-tv.metta
+++ b/experiments/truth-values/tests/test-est-tv.metta
@@ -6,8 +6,8 @@
 ! (import! &self experiments:utils:surp-utils)
 ! (import! &self experiments:utils:miner-utils)
 ! (import! &self experiments:utils:gen_partition)
-! (import! &self experiments:rules:est-tv)
-! (import! &self experiments:rules:emp-tv)
+! (import! &self experiments:truth-values:est-tv)
+! (import! &self experiments:truth-values:emp-tv)
 ! (import! &kb experiments:data:ugly_man_sodaDrinker)
 
 ! (bind! square (py-atom numpy.square (-> Number Number)))

--- a/experiments/truth-values/tests/test-est-tv.metta
+++ b/experiments/truth-values/tests/test-est-tv.metta
@@ -14,7 +14,7 @@
 
 
 
-!(do-ji-tv-est  &db (,(Inheritance $x sodaDrinker) (Inheritance $x human) (Inheritance $x woman)) $emp)
+!(do-ji-tv-est  &kb (,(Inheritance $x ugly) (Inheritance $x man) (Inheritance $x sodaDrinker)) $emp)
 
 
 

--- a/experiments/utils/surp-utils.metta
+++ b/experiments/utils/surp-utils.metta
@@ -61,8 +61,8 @@
               (($head $tail) (decons-atom $pattern_list))
               ($new_head (remove-parenthesis $head)) ;; to remove unnecessary parenthesis if there is any
               ($emp_value (
-                 unify (Inheritance $x $y) $new_head  (emp-tv $new_head $db) 
-                       (chain (conjunct-pattern $new_head $db) $ptrn (emp-tv $ptrn $db))));;conjunct if it is not single pattern 
+                 unify ($link $x $y) $new_head  (emp-tv $new_head $db) 
+                       (chain (cons-atom , $new_head) $ptrn (emp-tv $ptrn $db))));;conjunct if it is not single pattern 
               ($dummy (emp_tv_mem $tail $db))
         )  
             (cons-atom  $emp_value $dummy)


### PR DESCRIPTION
Problem:
- While testing joint-independent-truth-value-estimation, results for ji-tv-est on (ugly man sodaDrinker) and (man ugly sodaDrinker) were inconsistent (order-dependent).
- Computed values differed from the OpenCog miner reference implementation.

Solution:
- Fixed multiple syntax and logical errors across several files:

1. test-est-tv.metta and SurprisingnessUTest.metta:
   - Corrected import paths:
     Old: (import! &self experiments:rules:est-tv)
     New: (import! &self experiments:truth-values:est-tv)
   - Updated test call to use the correct database variable:
     Old: !(do-ji-tv-est  &db ...)
     New: !(do-ji-tv-est  &kb ...)

2. surp-utils.metta:
   - Replaced unnecessary function that added patterns to the database:
     Old: (conjunct-pattern $new_head $db)
     New: (cons-atom , $new_head)
   - Generalized unification to handle all links, not just Inheritance:
     Old: unify (Inheritance $x $y)
     New: unify ($link $x $y)

3. emp-tv.metta:
   - Updated confidence calculation to use the correct constant:
     Old: Default_k = 1
     New: DEFAULT_K = 800
   - Fixed argument order in sup-num call within emp-tv:
     Old: (sup-num $pattern $db)
     New: (sup-num $db $pattern)

Result:
- After these corrections, our implementation now matches the OpenCog miner output for the test case:
  !(do-ji-tv-est  &kb (,(Inheritance $x ugly) (Inheritance $x man) (Inheritance $x sodaDrinker)) $emp)
  Result: (STV 0 0.00027229280235977334)
  OpenCog: (stv 0 0.000272293)