### PR TITLE
update superpose function

### DIFF
--- a/experiments/utils/gen_partition.metta
+++ b/experiments/utils/gen_partition.metta
@@ -172,12 +172,12 @@
 ;; ===========================================================================
 
 (= (powerset-without-empity $list)
-    (collapse
+  (let $subset (powerset $list) (collapse
         (subtraction
-            (superpose (powerset $list))
+            (superpose $subset)
             (superpose (()))
         )
-    )
+    ))
 )
 
 


### PR DESCRIPTION
This pull request updates the `powerset-without-empity` function in `gen_partition.metta` to improve code clarity and efficiency. The main change is the introduction of a local variable to avoid recomputing the powerset multiple times.

Code clarity and efficiency:

* Refactored the `powerset-without-empity` function to use a local variable `$subset` for storing the result of `powerset $list`, preventing redundant computation and improving readability.