### PR TITLE
create a function that generet and select rundome subsample

### DIFF
--- a/experiments/utils/bs-utils.metta
+++ b/experiments/utils/bs-utils.metta
@@ -1,4 +1,6 @@
+
 !(import! &self  emp-tv-bs)
+
 
 ;; =============================================================================
 ;; Function: subsample-py
@@ -14,13 +16,6 @@
 ;; Output:
 ;;   - A new space containing the randomly selected atoms
 ;;
-;; How it works:
-;;   1. Extracts all atoms from the source database using `get-atoms`
-;;   2. Collapses the result into a flat list
-;;   3. Randomly selects `$subsize` atoms using `generet_random_subsample`
-;;   4. Creates a copy of the selected atoms in a new space
-;;
-
 ;; =============================================================================
 (= (subsample-py $db $subsize)
     (let* (
@@ -31,7 +26,90 @@
     )
 )
 
+;; avrg-tv-py
+;; Computes the arithmetic mean of a sequence of numerical values.
+;; 
+;; Parameters:
+;;   x – A sequence of numerical values (e.g., time-series data).
+;; 
+;; Returns:
+;;   The average (mean) of the values in `x`.
+;; 
+;; Note:
+;;   This function is an alias for `mean-tv`.
+
 (= (avrg-tv-py $x) (mean-tv $x))
 
 
+
+;; =============================================================================
+;; Function: get-element-by-Index
+;; -----------------------------------------------------------------------------
+;; Purpose:
+;;   Retrieves an element from a list at a specified index position.
+;;
+;; Parameters:
+;;   - $list: The input list to access
+;;   - $index: Zero-based index of the element to retrieve
+;;
+;; Returns:
+;;   - The element at the specified index
+;;   - Undefined behavior if index is out of bounds
+;; =============================================================================
+
+(= (get-element-by-Index $list $index)
+       (index-atom $list $index)
+)
+      
+
+;; =============================================================================
+;; Function: random-element
+;; -----------------------------------------------------------------------------
+;; Purpose:
+;;   Selects and returns a random element from the given database ($db).
+;;
+;; Parameters:
+;;   - $db: A database or collection from which atoms are extracted.
+;;
+;;
+;; Returns:
+;;   - A randomly selected element from the database.
+;;
+;; =============================================================================
+(= (random-element $db)
+   (let* (
+           ($list (collapse (get-atoms $db)))
+           ($length (size-atom $list))
+           ($index (random-int 0 $length))
+           ($element (get-element-by-Index $list $index))
+         )
+         $element))
+
+
+
+;; =============================================================================
+;; Function: generet-random-subsample
+;; -----------------------------------------------------------------------------
+;; Purpose:
+;;   Generates a random subsample of elements from the provided database ($db)
+;;   with the specified sample size ($subsize). The subsample is collected 
+;;   recursively.
+;;
+;; Parameters:
+;;   - $db: The database or collection to sample from.
+;;   - $subsize: The desired size of the random subsample.
+;;
+;; Returns:
+;;   - A list containing a random subsample of elements from the database.
+(= (generet-random-subsample $db $subsize)
+   (if (== $subsize 0)
+       ()
+       (let* (             
+               ($elements (random-element $db))
+               ($tail-elements (generet-random-subsample $db (- $subsize 1)))
+             )
+             (cons-atom $elements $tail-elements)
+       )
+   )
+)
 


### PR DESCRIPTION
This pull request adds several utility functions to the `experiments/utils/bs-utils.metta` file, enhancing its capabilities for sampling and list operations. The new functions include random element selection, subsampling, list indexing, and an average calculation alias. Additionally, some outdated comments were removed for clarity.

**New utility functions and enhancements:**

* Added `avrg-tv-py` as an alias for `mean-tv`, allowing calculation of the average of a sequence.
* Introduced `get-element-by-Index` to retrieve an element from a list at a specified index.
* Added `random-element` to select a random element from a database or collection.
* Implemented `generet-random-subsample` to generate a random subsample of elements from a database, using recursion.

**Code cleanup:**

* Removed outdated or redundant comments from the `subsample-py` function for improved clarity.