### PR TITLE
Add method that remove hashtag

### DIFF
--- a/experiments/utils/gen_partition.metta
+++ b/experiments/utils/gen_partition.metta
@@ -208,3 +208,34 @@
     )
 
 )
+
+
+;; ===========================================================================
+;; FUNCTION: remove-hashtag
+;;
+;; DESCRIPTION:
+;;   Processes an expression and removes all occurrences of the `#` symbol
+;;   from variable names. This is used to normalize variables that enter or
+;;   leave the space, ensuring they are represented without the hashtag.
+;;
+;; PARAMETERS:
+;;   • $x — An expression potentially containing variables with `#` in their names.
+;;
+;; RETURNS:
+;;   A transformed expression where all variables have been stripped of `#`.
+;;
+;; EXAMPLE:
+;;   (remove-hashtag '(#x + #y))
+;;   ⇒ (x + y)
+;;
+;;   (remove-hashtag '(foo #bar #baz))
+;;   ⇒ (foo bar baz)
+;; ===========================================================================
+
+((= remove-hashtag $x) 
+    (remove-hashtag-py $x))
+
+
+
+
+

--- a/experiments/utils/partition/main.py
+++ b/experiments/utils/partition/main.py
@@ -90,6 +90,14 @@ def generate_partitions(metta, subsets, original):
 
     return atom
 
+def remove_hashtag(metta, expression):
+    # Remove hashtags from the expression
+    print("Removing hashtags from:", expression)
+    value = get_string_value(expression)
+    value = re.sub(r"#\w+", "", value)
+    return metta.parse_all(value)
+
+   
 
 @register_atoms(pass_metta=True)
 def generete_partionReg(metta: MeTTa):
@@ -97,9 +105,11 @@ def generete_partionReg(metta: MeTTa):
     # Define the operation atom with its parameters and function
     generatePartiton = OperationAtom('generate-partitions', lambda a, b: generate_partitions(metta, a, b),
                                      ['Expression', 'Expression', 'Expression'], unwrap=False)
-    # generateRandomVar = OperationAtom('generateRandomVar', lambda a, b: (print(S(a),S(b)),generate_random_var(metta,a, b)[1],['Atom', 'Atom', 'Expression'], unwrap=False))
+
+    removeHashtag = OperationAtom('remove-hashtag-py', lambda a: remove_hashtag(metta, a),
+                                     ['Expression', 'Expression'], unwrap=False)
 
     return {
-        r"gen-partition": generatePartiton
-
+        r"gen-partition": generatePartiton,
+        r"remove-hashtag-py": removeHashtag
     }


### PR DESCRIPTION
This pull request introduces a new utility for normalizing variable names by removing hashtags from expressions, both in the Metta and Python codebases. The main focus is on providing a consistent way to strip the `#` symbol from variable names in expressions, which is useful for standardizing data as it enters or leaves a processing space.

**New hashtag removal functionality:**

* Added a new `remove-hashtag` function in `gen_partition.metta` that removes all occurrences of the `#` symbol from variable names in an expression, with documentation and usage examples.
* Implemented a corresponding `remove_hashtag` function in `main.py` that uses regex to strip hashtags from expressions and parses the cleaned result.
* Registered the new `remove-hashtag-py` operation in the Python-to-Metta atom registration, making it accessible as an operation alongside `gen-partition`.