### PR TITLE
feat: Add interactive resampling and optimize emp-tv functions

### DIFF
--- a/experiments/surprisingness/emp-prob.metta
+++ b/experiments/surprisingness/emp-prob.metta
@@ -237,7 +237,7 @@
                 
                 ($subsize (subsmp-size $pattern $db-size $support-estimate))
                 
-                    ($n-resample 10)
+                    ($n-resample (let $x (py-input "how many re-samples do you want:- " ) $x))
                     ($emp-prob (emp_prob_bs $pattern $db $n-resample $subsize))
                     
                     )

--- a/experiments/truth-values/emp-tv.md
+++ b/experiments/truth-values/emp-tv.md
@@ -205,12 +205,12 @@ This document provides an overview of several Metta functions used for calculati
 - **Output:**  
   - A random integer in the specified range.
 
-### `get-element`
+### `get-element-by-index`
 - **Description:**  
   Retrieves an element from a list based on its index.
 - **Inputs:**  
-  - `$index`: The position of the element in the list.  
   - `$list`: The list from which to retrieve the element.
+  - `$index`: The position of the element in the list.  
 - **Output:**  
   - The element at the given index.
 
@@ -259,7 +259,7 @@ This document provides an overview of several Metta functions used for calculati
 - **Output:**  
   - A numerical value representing the chosen subsample size, ensuring it is not below a minimum threshold and does not exceed the database size.
 
-### `mk-stv`
+### `mk_stv`
 - **Description:**  
   Constructs a statistical truth value based on the mean and variance of empirical truth values.
 - **Inputs:**  

--- a/experiments/truth-values/emp-tv.metta
+++ b/experiments/truth-values/emp-tv.metta
@@ -240,22 +240,14 @@
 ;;   - $old-db-content: The content of the original database that needs to be duplicated.
 ;;
 ;; Internal Calculation:
-;;   1. If the $old-db-content is empty, return the original database as is.
-;;   2. Otherwise, add the first element of the content (car-atom) to the new database using `add-reduct`.
-;;   3. Recursively process the rest of the content (cdr-atom) to continue copying the remaining data.
+;;   1. by leveraging add-reducts function , add all the old-content to the given db.
 ;;   
 ;; Returns:
 ;;   - A new database instance containing all the data from the original database.
 ;; =============================================================================
 (= (copy-db $db $old-db-content)
-    (if (== $old-db-content ()) $db
-        (let* (
-                (($head $tail) (decons-atom $old-db-content))
-                ($_ (add-atom $db $head) )
-            )
-        (copy-db $db $tail)
-    )
-))
+    ( let $_ (collapse (add-reducts $db $old-db-content)) $db)  
+)
 
 ;; =============================================================================
 ;; Function: add_n_atoms_to_db
@@ -276,10 +268,11 @@
 ;;   - The database with the specified number of atoms added.
 ;; =============================================================================
 (= (add_n_atoms_to_db $db $n)
-    (if (<= $n 0) $db
-        (let* ( ($_ (add-atom $db Pattern))
-            )
-        (add_n_atoms_to_db $db (- $n 1))
+    (if (<= $n 0) 
+        $db
+        (   
+            let $_ (add-atom $db Pattern)
+                (add_n_atoms_to_db $db (- $n 1))
     )
 ))
 
@@ -556,7 +549,7 @@
 ;;   1. If the subsample size is less than the database size, the function performs resampling:
 ;;      - Calls `emp-tv-bs-helper` to generate multiple empirical truth values (one for each resample).
 ;;      - Averages the resampled empirical truth values using `avrg-tv-py`.
-;;      - Calls `mk-stv` to create a simple truth value from the mean and variance of the empirical truth values.
+;;      - Calls `mk_stv` to create a simple truth value from the mean and variance of the empirical truth values.
 ;;   2. If the subsample size is greater than or equal to the database size, it directly calculates the empirical truth value using `emp-tv`.
 ;;
 ;; Returns:
@@ -567,9 +560,8 @@
     (if (< $subsize (db_size $db))
         (let* (
                 ($esstvs (emp-tv-bs-helper $pattern $db $n-resample $subsize))
-                ((EMPTV $mean $variance) (avrg-tv-py $esstvs))
-                ($mk_stv_val (mk_stv $mean $variance))
-                ($finalAnswer (cons-atom EMPTV $mk_stv_val))
+                ($avrg_value (avrg_tv $esstvs))
+                ($finalAnswer (cons-atom EMPTV $avrg_value))
             )
             $finalAnswer
         ) ; Return average of the empirical truth values
@@ -616,7 +608,7 @@
         ($support_estimate (prob_to_support $pattern $db $prob_estimate))
         ($db-size (* (db_size $db) $db_ratio))
         ($subsize (subsmp-size $pattern $db-size $support_estimate))
-        ($n-resample 10)
+        ($n-resample (let $x (py-input "how many re-samples do you want:- " ) $x))
         )
         (if (> $support_estimate $db-size)
             (emp-tv-bs $pattern $db $n-resample $subsize)

--- a/experiments/truth-values/tests/test-emp-tv.metta
+++ b/experiments/truth-values/tests/test-emp-tv.metta
@@ -42,7 +42,7 @@
 ;; Verifies counting of matching patterns in the knowledge base
 ;; Expected: 60 instances of (Inheritance $x $y)
 ;; =============================================================================
-!(assertEqual (sup (Inheritance $x $y) (get-space)) 60)
+!(assertEqual (sup-num (get-space) (Inheritance $x $y)) 60)
 
 ; ;; =============================================================================
 ; ;; Test: List Element Access
@@ -50,14 +50,14 @@
 ; ;; Verifies zero-based indexing of knowledge base elements  
 ; ;; Expected: Third element is (Inheritance Bob human)
 ; ;; =============================================================================
-!(assertEqual (get-element 2 ((Inheritance Abe human) 
+!(assertEqual (get-element-by-Index ((Inheritance Abe human) 
                              (Inheritance Rio human)
                              (Inheritance Bob human)
                              (Inheritance Mike human)
                              (Inheritance Mike Nil)
                              (Inheritance Zac human)
                              (Inheritance Zac human)
-                             (Parent Abe Nil)))
+                             (Parent Abe Nil)) 2)
               (Inheritance Bob human))
 
 ; ;; =============================================================================
@@ -85,10 +85,10 @@
 ; ;; Test: Simple Truth Value Construction  
 ; ;; -----------------------------------------------------------------------------
 ; ;; Verifies EMPTV struct creation from raw values
-; ;; Expected: (EMPTV 0 0.00012498)
+; ;; Expected: (0 0.00012498)
 ; ;; =============================================================================
-!(assertEqual (mk-stv 1.7689693569125715 1.0178393379503528)
-              (EMPTV 0 0.0001249843769528809))
+!(assertEqual (mk_stv 1.7689693569125715 1.0178393379503528)
+              (0 0.0001249843769528809))
 
 ;; =============================================================================
 ;; Test: Universe Counting

--- a/experiments/utils/beta-dist.metta
+++ b/experiments/utils/beta-dist.metta
@@ -38,31 +38,20 @@
 
 (=(mean_accumulater $tv_list $pre_value)(
    if (== $tv_list ()) $pre_value (
-       let* (
-           ($head (car-atom $tv_list));;(Beta (mean 54) (variance 57))
-           ($tail (cdr-atom $tv_list))
-           ($mean_value (get_beta_mean_var $head mean)) ;; 54
-           ($accumulate (+ $mean_value $pre_value))
-           ($dummy (mean_accumulater $tail $accumulate))
-       )
-            $dummy
+       let (Beta (mean $mean) $_) (car-atom $tv_list) ;;(Beta (mean 54) (variance 57))    
+            (mean_accumulater (cdr-atom $tv_list) (+ $mean $pre_value))
    )
-))
-
+))  
 
 (=(var_accumulater $tv_list $pre_value $mean)(
     if (== $tv_list ()) $pre_value (
-        let* (
-            ($head (car-atom $tv_list));;(Beta (mean 54) (variance 57))
-           ($tail (cdr-atom $tv_list))
-           ($mean_value_i (get_beta_mean_var $head mean))
-           ($variance (get_beta_mean_var $head var))
-           ($diff (- $mean_value_i $mean))
-           ($relative_var (+ $variance (* $diff $diff)))
-           ($rel_var_sum (+ $relative_var $pre_value))
-           ($dummy (var_accumulater $tail $rel_var_sum $mean))
+        let* ( 
+            ((Beta (mean $mean_value_i) (variance $variance)) (car-atom $tv_list)) 
+            ($diff (- $mean_value_i $mean))
+            ($relative_var (+ $variance (* $diff $diff)))
+            ($rel_var_sum (+ $relative_var $pre_value)) 
         )
-           $dummy
+            (var_accumulater (cdr-atom $tv_list) $rel_var_sum $mean)
     )
 ))
 
@@ -116,7 +105,7 @@
 )
 
 
-; This function `mk-stv` creates a standard truth value (STV) using the provided mean and variance.
+; This function `mk_stv` creates a standard truth value (STV) using the provided mean and variance.
  ; It calculates the alpha and beta parameters based on the mean and variance.
  ; It then computes the count and confidence values using these parameters.
  ; The mode is determined based on the values of alpha and beta, following specific conditions.

--- a/experiments/utils/bs-utils.metta
+++ b/experiments/utils/bs-utils.metta
@@ -1,6 +1,17 @@
 
 !(import! &self  emp-tv-bs)
 
+;; py-input
+;; takes input from the terminal through python
+;; 
+;; Parameters:
+;;   prompt – user informing message for the input.
+;; 
+;; Returns:
+;;   The number received from the user
+
+(= (py-input $x) (takingInput $x))
+
 
 ;; =============================================================================
 ;; Function: subsample-py

--- a/experiments/utils/common-utils.metta
+++ b/experiments/utils/common-utils.metta
@@ -812,10 +812,9 @@ let* ( ($pattern (cons-atom , $blks)) ($dummy (add-atom $db $pattern))) $pattern
 ; )
 ; )
 (= (n_conjuncts $pattern) (
-        if (not (is-pattern-et $pattern))
-        0
- (let $che (has-type , $pattern) (if $che (get-arity $pattern) 1)))
-            
+        if (== (get-metatype $var) Symbol)
+            0
+            (let $che (has-type , $pattern) (if $che (get-arity $pattern) 1)))
         )
 
 ;; Function: intilize

--- a/experiments/utils/emp-tv-bs/main.py
+++ b/experiments/utils/emp-tv-bs/main.py
@@ -12,6 +12,9 @@ import numpy as np
 
 DEFAULT_K = 800.0
 
+def register_input(prompt):
+    print("i am in register input, python function")
+    return [metta.parse_single(input(prompt))]
 
 def get_beta_distribution(emp_tv):
     emp_tv = emp_tv.get_children()  # cdr-atom
@@ -154,7 +157,11 @@ def avrage_tv(metta: MeTTa):
     random_subsample = OperationAtom('generet_random_subsample', lambda db_elemet, subsize:  generet_random_subsample(metta, db_elemet, subsize),
                                      ['Expression', 'Atom', 'Expression'], unwrap=False)
 
+    takeInput = OperationAtom("takingInput", lambda prompt: register_input(prompt),
+    ["Atom" , "Atom"], unwrap=False)
+
     return {
         r"mean-tv": avrageTv,
         r"generet_random_subsample": random_subsample,
+        r"takingInput": takeInput,
     }

--- a/experiments/validation/emp_tv.validation.metta
+++ b/experiments/validation/emp_tv.validation.metta
@@ -107,7 +107,7 @@
    &db        ; knowledge base: ugly-man-soda-drinker
    0.02          ; database ratio
 ) (stv 0 0.0001249843769528809))
-)
+
 
 ; ===============================
 ; Parameters Info
@@ -146,7 +146,7 @@
    &db        ; knowledge base: ugly-man-soda-drinker
    0.02          ; database ratio
 ) (stv 0.0 0.09963099630996311))
-)
+
 
 ; ===============================
 ; Parameters Info


### PR DESCRIPTION
--code optimizations, This PR enhances the empirical truth-value module with interactive resampling, major performance optimizations, and validation fixes. 

- used sup-num for more efficient pattern matching, inside the emp-test file.
- Refactored universe-count to avoid unnecessary function calls; replaced deep call stacks with direct symbol checks.
- Adopted the MeTTa implementation of avrg_tv.
- Optimized mean_accumulater and var_accumulater for clarity and performance.
- Replaced recursion in copy-db with add-reducts for efficiency.
- Improved readability and performance of add_n_atoms_to_db.