### PR TITLE
Add our_alpha_member function and update imports in newMain.metta

### DIFF
--- a/experiments/newMiner/helperPro.pl
+++ b/experiments/newMiner/helperPro.pl
@@ -1,0 +1,9 @@
+
+%% our_alpha_member(+Elem, +List, -Result)
+%% Result = true if Elem is alpha-equal (=@=) to any element in List, else false
+%% our_alpha_member(+Elem, +List, -Result)
+%% Checks if Elem is alpha-equal (=@=) to any element in List.
+our_alpha_member(_, [], false).
+our_alpha_member(Elem, [H|_], true) :- Elem =@= H, !.
+our_alpha_member(Elem, [_|Rest], Result) :- our_alpha_member(Elem, Rest, Result).
+

--- a/experiments/newMiner/newMain.metta
+++ b/experiments/newMiner/newMain.metta
@@ -5,13 +5,14 @@
 !(import! &self ../utils/surp-utils/blk-abstractness)
 !(import! &self ../utils/remove_useless_clauses)
 
-; !(import! &self "C:/Users/Vertx/Desktop/coding/Metta/PeTTa/lib/lib_import.metta") ;add local path of PeTTa's lib
-!(import! newDB ../data/testDataSet) ;add local path of your db
+!(import! &self "C:/Users/Vertx/Desktop/coding/Metta/PeTTa/lib/lib_import.metta") ;add local path of PeTTa's lib
+!(import! newDB ../data/ugly_man_sodaDrinker) ;add local path of your db
+!(import_prolog_functions_from_file "C:/Users/Vertx/Desktop/coding/Metta/hyperon-miner/experiments/newMiner/helperPro.pl" (our_alpha_member))
 
 ;; check function
 ( = (conjunctChecker $db $conjunct $cnjSpace $ms)
     ; return the conjunct if (not (is-member-custom $conjunct $cnjSpace)) && (main-func $conjunct ()) && (sup-evalCustom $db $conjunct $ms)
-    (let $bool1 (not (alpha_member $conjunct $cnjSpace)) ; (== () (collapse (eval (is_member $cnjSpace $conjunct)))) ;(is-member-custom $conjunct $cnjSpace)
+    (let $bool1 (not (our_alpha_member $conjunct $cnjSpace)) ; (== () (collapse (eval (is_member $cnjSpace $conjunct)))) ;(is-member-custom $conjunct $cnjSpace)
         (if $bool1              
             (let $bool2 (check-disj $conjunct)
                 (if $bool2
@@ -128,5 +129,5 @@
 
 
 !(--------------------- main miner with specialization step ---------------)
-!(let $x (mainMiner newDB 500000 3) (println! (conj :- (superpose $x) )))
+!(let $x (mainMiner newDB 5 3) (println! (conj :- (superpose $x) )))
 !(-------------------------------------------------------------------------)


### PR DESCRIPTION
This pull request introduces a new helper function for alpha-equivalence checking in Prolog and updates the Metta main script to use this new function for more accurate membership checks.

Key changes:

**Alpha-equivalence and membership checking:**
* Added the Prolog function `our_alpha_member` in `helperPro.pl` to check if an element is alpha-equivalent to any element in a list, returning a boolean result.
* Imported the `our_alpha_member` function into `newMain.metta` and replaced previous membership checks with calls to this new function for improved accuracy in conjunct checking.